### PR TITLE
support `authenticated` as a function

### DIFF
--- a/lib/__tests__/plugin.js
+++ b/lib/__tests__/plugin.js
@@ -73,6 +73,64 @@ describe('Middleware', () => {
       })
     })
   })
+
+  describe('when using a function for the authenticated option', () => {
+    describe('with an authenticated component', () => {
+      let authenticatedMock
+
+      beforeEach(() => {
+        authenticatedMock = jest.fn(() => true)
+        const comp = { components: [{ options: { authenticated: authenticatedMock } }] }
+        context.route.matched.push(comp)
+      })
+
+      it('redirects', async () => {
+        await (Middleware.auth(context))
+
+        expect(context.redirect).toHaveBeenCalled()
+      })
+
+      it('calls authenticated', async () => {
+        await (Middleware.auth(context))
+
+        expect(authenticatedMock).toHaveBeenCalled()
+        expect(authenticatedMock).toHaveBeenCalledWith({
+          options: { authenticated: authenticatedMock }
+        })
+      })
+
+      describe('with an access token', () => {
+        beforeEach(() => {
+          context.store.state.oauth.accessToken = 'i am an access token'
+        })
+
+        it('does nothing', async () => {
+          await (Middleware.auth(context))
+
+          expect(context.redirect).not.toHaveBeenCalled()
+        })
+      })
+    })
+
+    describe('with an unauthenticated component', () => {
+      let unAuthenticatedMock
+
+      beforeEach(() => {
+        unAuthenticatedMock = jest.fn(() => false)
+        const comp = { components: [{ options: { authenticated: unAuthenticatedMock } }] }
+        context.route.matched.push(comp)
+      })
+
+      it('does not redirect', async () => {
+        await (Middleware.auth(context))
+
+        expect(unAuthenticatedMock).toHaveBeenCalledWith({
+          options: { authenticated: unAuthenticatedMock }
+        })
+        expect(context.redirect).not.toHaveBeenCalled()
+      })
+    })
+  })
 })
 
 describe('Helpers', () => {

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -20,10 +20,13 @@ const initStore = async context => {
   })
 }
 
+const isAuthenticatedRoute = component =>
+  typeof component.options.authenticated === 'function' ? component.options.authenticated(component) : component.options.authenticated
+
 const checkAuthenticatedRoute = ({ route: { matched } }) => process.client
-  ? matched.some(({ components }) => Object.values(components).some(c => c.options.authenticated))
+  ? matched.some(({ components }) => Object.values(components).some(c => isAuthenticatedRoute(c)))
   : matched.some(({ components }) => Object.values(components).some(({ _Ctor }) =>
-    Object.values(_Ctor).some(({ options }) => options && options.authenticated)))
+    Object.values(_Ctor).some(c => c.options && isAuthenticatedRoute(c))))
 
 middleware.auth = async context => {
   await initStore(context)

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
   "author": "samtgarson@gmail.com",
   "license": "MIT",
   "scripts": {
-    "test": "NODE_ENV=test jest",
+    "test": "yarn test:unit && yarn test:e2e",
+    "test:unit": "jest lib",
+    "test:e2e": "NODE_ENV=test jest e2e.js",
     "lint": "eslint --ignore-path .gitignore .",
     "start": "nuxt -c ./__tests__/fixture/nuxt.config.js"
   },


### PR DESCRIPTION
can now support the option `authenticated` being a function which returns a bool.

Also updated test scripts lightly.