### PR TITLE
Catch errors in fetchUser

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ oauth: {
   oauthHost: process.env.OAUTH_HOST,
   oauthClientID: process.env.OAUTH_CLIENT_ID,
   oauthClientSecret: process.env.OAUTH_CLIENT_SECRET,
+  getOauthHost: req => req.params.oauth_host,
   onLogout: (req, res) => {
     // do something after logging out
   },
@@ -80,11 +81,12 @@ export default {
 | `oauthHost` | * | Host of your OAuth provider _(usually ending in `oauth` or `oauth2`)_ |
 | `oauthClientID` | * | Client ID of your application, registered with your OAuth provider |
 | `oauthClientSecret` | * | Client ID of your application, registered with your OAuth provider |
+| `getOauthHost` |  | Optional hook to define `oauthHost` at runtime, which falls back to `oauthHost` in case of error. _Receives args `(req)`._ |
 | `scopes` |  | An array of scopes to authenticate against |
 | `authorizationPath` |  | The path to redirect users to authenticate _(defaults to `/authorize`)_ |
 | `accessTokenPath` |  | The path to request the access token _(defaults to `/token`)_ |
 | `onLogout` | | Optional hook which is called after logging out. E.g. can be used to perform a full log out on your OAuth provider. _Receives args `(req, res, redirectUrl)`.  Can be asynchronous (or return a promise)._ |
-| `fetchUser` | | Optional hook which is called when logging in to fetch your user object. _Receives args `(accessToken, request)`._ |
+| `fetchUser` | | Optional hook which is called when logging in to fetch your user object. _Receives args `(accessToken, request, options)`._ |
 | `testMode` | | Flag which tells the module to ignore the OAuth dance and log every one in _(see [here](#with-your-tests) for more)_. |
   
 ### Helpers

--- a/lib/__tests__/handler.js
+++ b/lib/__tests__/handler.js
@@ -10,6 +10,7 @@ jest.mock('client-sessions', () => jest.fn(() => (req, res, resolve) => resolve(
 let req
 let res
 let options
+let errorOptions
 let token
 let refreshedToken
 let reqWithSession
@@ -17,6 +18,8 @@ let reqWithHttps
 let mockToken
 let savedSession
 let user
+
+const error = new Error('I am a teapot')
 
 beforeEach(() => {
   req = {
@@ -37,6 +40,11 @@ beforeEach(() => {
     secretKey: 'sekret',
     fetchUser: jest.fn(() => user),
     onLogout: jest.fn(() => {})
+  }
+  errorOptions = {
+    ...options,
+    fetchUser: () => { throw error },
+    onLogout: () => { throw error }
   }
   token = {
     accessToken: 'accessToken',
@@ -140,15 +148,23 @@ describe('Handler', () => {
   describe('#saveData', () => {
     let handler
     let testToken
+    let testOptions
+    let thrownError
 
     beforeAll(() => {
       testToken = token
+      testOptions = options
     })
 
     beforeEach(async () => {
-      handler = new Handler({ req: reqWithSession, res, options })
+      handler = new Handler({ req: reqWithSession, res, options: testOptions })
       handler.createSession = jest.fn(async () => {})
-      await handler.saveData(testToken)
+      try {
+        await handler.saveData(testToken)
+      } catch (e) {
+        thrownError = e
+        console.error(thrownError)
+      }
     })
 
     it('creates a session', () => {
@@ -166,23 +182,22 @@ describe('Handler', () => {
       })
 
       it('fetches the user', () => {
-        expect(options.fetchUser).toHaveBeenCalledWith(token.accessToken, handler.req)
+        expect(testOptions.fetchUser).toHaveBeenCalledWith(token.accessToken, handler.req, testOptions)
       })
 
       it('saves the user to the session and the request', () => {
         expect(handler.req[options.sessionName].user).toEqual(user)
         expect(handler.req.user).toEqual(user)
       })
+    })
 
-      describe('with a fetchUser that throws an error', () => {
-        beforeEach(async () => {
-          options.fetchUser = async () => { throw new Error('I am a teapot') }
-          handler = new Handler({ req: reqWithSession, res, options })
-        })
+    describe('with a fetchUser that throws an error', () => {
+      beforeAll(async () => {
+        testOptions = errorOptions
+      })
 
-        it.only('does not raise an error', async () => {
-          await expect(handler.saveData(token)).resolves.toBeTruthy()
-        })
+      it('does not raise an error', async () => {
+        expect(thrownError).toBeUndefined()
       })
     })
 
@@ -288,17 +303,26 @@ describe('Handler', () => {
     let handler
     let testRes
     let testReq
+    let testOptions
+    let thrownError
 
     beforeAll(() => {
       testRes = {}
       testReq = { ...reqWithSession, url: '/path?redirect-url=/new-path' }
+      testOptions = options
     })
 
     beforeEach(async () => {
-      handler = new Handler({ req: testReq, res: testRes, options })
+      handler = new Handler({ req: testReq, res: testRes, options: testOptions })
       handler.createSession = jest.fn(async () => {})
       handler.redirect = jest.fn(async () => {})
-      await handler.logout()
+
+      try {
+        await handler.logout()
+      } catch (e) {
+        thrownError = e
+        console.error(thrownError)
+      }
     })
 
     it('resets the session', () => {
@@ -307,7 +331,13 @@ describe('Handler', () => {
     })
 
     it('it calls the logout callback', () => {
-      expect(options.onLogout).toHaveBeenCalledWith(testReq, testRes, '/new-path')
+      expect(testOptions.onLogout).toHaveBeenCalledWith(testReq, testRes, '/new-path')
+    })
+
+    describe('for a logout callback which throws an error', () => {
+      it('does not throw an error', () => {
+        expect(thrownError).toBeUndefined()
+      })
     })
 
     describe('for a logout callback which redirects', () => {

--- a/lib/__tests__/handler.js
+++ b/lib/__tests__/handler.js
@@ -173,6 +173,17 @@ describe('Handler', () => {
         expect(handler.req[options.sessionName].user).toEqual(user)
         expect(handler.req.user).toEqual(user)
       })
+
+      describe('with a fetchUser that throws an error', () => {
+        beforeEach(async () => {
+          options.fetchUser = async () => { throw new Error('I am a teapot') }
+          handler = new Handler({ req: reqWithSession, res, options })
+        })
+
+        it.only('does not raise an error', async () => {
+          await expect(handler.saveData(token)).resolves.toBeTruthy()
+        })
+      })
     })
 
     describe('for a null token', () => {

--- a/lib/__tests__/server-middleware.js
+++ b/lib/__tests__/server-middleware.js
@@ -36,6 +36,49 @@ describe('Server Middleware', () => {
     expect(Handler).toHaveBeenCalledWith({ req, res, next, options })
   })
 
+  describe('with getOauthHost', () => {
+    const getter = jest.fn(({ url }) => url)
+
+    beforeEach(async () => {
+      const fnOptions = {
+        ...options,
+        getOauthHost: getter
+      }
+      middleware = Middleware(fnOptions)
+      await middleware(req, res, next)
+    })
+
+    describe('normally', () => {
+      it('calls the function', () => {
+        expect(getter).toHaveBeenCalledWith(req)
+      })
+
+      it('passes through the result', () => {
+        expect(Handler).toHaveBeenCalledWith({
+          req,
+          res,
+          next,
+          options: expect.objectContaining({ oauthHost: req.url })
+        })
+      })
+    })
+
+    describe('when getOauthHost throws an error', () => {
+      beforeAll(() => {
+        getter.mockImplementationOnce(() => { throw new Error('I am a teapot') })
+      })
+
+      it('falls back to oauthHost', () => {
+        expect(Handler).toHaveBeenCalledWith({
+          req,
+          res,
+          next,
+          options: expect.objectContaining({ oauthHost: options.oauthHost })
+        })
+      })
+    })
+  })
+
   describe('for a normal route', () => {
     it('updates the token', async () => {
       await middleware(req, res, next)

--- a/lib/handler.js
+++ b/lib/handler.js
@@ -84,7 +84,7 @@ Handler.prototype.saveData = async function saveData (token) {
 
   const fetchUser = async () => {
     try {
-      return await this.opts.fetchUser(accessToken, this.req)
+      return await this.opts.fetchUser(accessToken, this.req, this.opts)
     } catch (e) {
       return {}
     }
@@ -133,7 +133,10 @@ Handler.prototype.logout = async function logout () {
   this.req[this.opts.sessionName].setDuration(0)
 
   const redirectUrl = parse(this.req.url.split('?')[1])['redirect-url'] || '/'
-  await this.opts.onLogout(this.req, this.res, redirectUrl)
+  try {
+    await this.opts.onLogout(this.req, this.res, redirectUrl)
+  } catch (err) {}
+
   if (this.res.headersSent) return
   this.redirect(redirectUrl)
 }

--- a/lib/handler.js
+++ b/lib/handler.js
@@ -82,7 +82,15 @@ Handler.prototype.saveData = async function saveData (token) {
   this.req[this.opts.sessionName].token = { accessToken, refreshToken, expires }
   this.req.accessToken = accessToken
 
-  const user = this.req[this.opts.sessionName].user || await this.opts.fetchUser(accessToken, this.req)
+  const fetchUser = async () => {
+    try {
+      return await this.opts.fetchUser(accessToken, this.req)
+    } catch (e) {
+      return {}
+    }
+  }
+
+  const user = this.req[this.opts.sessionName].user || await fetchUser()
   this.req[this.opts.sessionName].user = user
   this.req.user = user
   return true

--- a/lib/server-middleware.js
+++ b/lib/server-middleware.js
@@ -4,6 +4,15 @@ const createTestHandler = require('./test-mode')
 
 module.exports = options => async (req, res, next) => {
   if (options.testMode) createTestHandler(Handler)
+
+  if (options.getOauthHost && typeof options.getOauthHost === 'function') {
+    try {
+      options.oauthHost = await options.getOauthHost(req)
+    } catch (err) {
+      if (process.env.NODE_ENV === 'development') console.error(err)
+    }
+  }
+
   const handler = new Handler({ req, res, next, options })
 
   // Start the OAuth dance

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-oauth",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "OAuth module for your Nuxt applications",
   "main": "index.js",
   "repository": "https://github.com/samtgarson/nuxt-oauth",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     ]
   },
   "jest": {
+    "clearMocks": true,
     "testPathIgnorePatterns": [
       "/node_modules/",
       "/__tests__/fixture/"


### PR DESCRIPTION
- Handles errors in `fetchUser` and `onLogout` - fixes #17
- Implements new options `getOauthHost` function which receives `req` - fixes #18
- Passes `options` to `fetchUser` - fixes #19 